### PR TITLE
Fix environment loading

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -5,11 +5,12 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as dotenv from 'dotenv';
+import { resolve } from 'path';
 import * as schema from './schema';
 
 // Charger les variables d'environnement si pas déjà fait
 if (!process.env.DATABASE_URL) {
-  dotenv.config({ path: '../../.env' });
+  dotenv.config({ path: resolve(__dirname, '../../../.env') });
 }
 
 // Configuration de la connexion PostgreSQL

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,9 +1,10 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import * as dotenv from 'dotenv';
+import { resolve } from 'path';
 
 // Charger les variables d'environnement depuis le fichier .env à la racine
-dotenv.config({ path: '../../.env' });
+dotenv.config({ path: resolve(__dirname, '../../../.env') });
 
 import { PingResponse, ApiInfo, ApiEndpoint } from '@/types';
 import { testConnection } from './db/connection';


### PR DESCRIPTION
## Summary
- fix `.env` path in backend server and DB connection so builds can read configuration

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688b6e5d9a488323834d74e62ef22037